### PR TITLE
fix: update release workflow for FBC compatibility

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -94,6 +94,13 @@ jobs:
     runs-on: ubuntu-latest
     needs: ["quay", "quay-operator", "quay-builder-qemu", "quay-builder"]
     steps:
+      - name: Strip v prefix from tag
+        id: tag
+        run: |
+          TAG="${{ github.event.inputs.tag }}"
+          TAG="${TAG#v}"
+          echo "version=$TAG" >> $GITHUB_OUTPUT
+
       - name: Check out Quay Operator repo
         uses: actions/checkout@v3
         with:
@@ -109,11 +116,12 @@ jobs:
 
           PREVIOUS_VERSION=$(
             for v in *; do
+              clean="${v#v}"
               if
                 [ -e "$v/metadata/annotations.yaml" ] &&
                 [ "$(yq '.annotations["operators.operatorframework.io.bundle.channels.v1"]' "$v/metadata/annotations.yaml")" = "$CHANNEL" ]
               then
-                echo "$v"
+                echo "$clean"
               fi
             done | sort -rV | head -n1
           )
@@ -122,9 +130,14 @@ jobs:
             REPLACES="quay-operator.v$PREVIOUS_VERSION"
           fi
 
-          mkdir -p ./${{ github.event.inputs.tag }}
+          mkdir -p ./${{ steps.tag.outputs.version }}
 
-          STABLE_Y_STREAM=$(ls -1d *.0 | sort -rV | head -n1)
+          STABLE_Y_STREAM=$(
+            for v in *.0 v*.0; do
+              [ -e "$v" ] || continue
+              echo "${v#v}"
+            done | sort -rV | head -n1
+          )
           DEFAULT_CHANNEL="stable-${STABLE_Y_STREAM%.0}"
 
           echo "replaces=$REPLACES" >> $GITHUB_OUTPUT
@@ -132,13 +145,15 @@ jobs:
 
       - name: Download manifests folder
         run: |
+          TAG="${{ steps.tag.outputs.version }}"
+
           git clone --branch ${{ github.event.inputs.branch }} https://${{ secrets.PAT }}@github.com/quay/quay-operator.git
 
           cd ./quay-operator
           make prepare-release \
             CHANNEL="${{ github.event.inputs.channel }}" \
             DEFAULT_CHANNEL="${{ steps.versions.outputs.default-channel }}" \
-            RELEASE="${{ github.event.inputs.tag }}" \
+            RELEASE="$TAG" \
             CLAIR_RELEASE="${{ github.event.inputs.clair-version }}" \
             REPLACES="${{ steps.versions.outputs.replaces }}"
           rm ./bundle/manifests/quay-operator.service.yaml
@@ -147,49 +162,71 @@ jobs:
           mv \
             ./quay-operator/bundle/manifests \
             ./quay-operator/bundle/metadata \
-            ./operators/project-quay/${{ github.event.inputs.tag }}
+            ./operators/project-quay/$TAG
 
           rm -rf ./quay-operator
+
+      - name: Generate release-config.yaml for FBC
+        run: |
+          TAG="${{ steps.tag.outputs.version }}"
+          REPLACES="${{ steps.versions.outputs.replaces }}"
+          CHANNEL="${{ github.event.inputs.channel }}"
+
+          printf '%s\n' \
+            "---" \
+            "catalog_templates:" \
+            "  - template_name: basic.yaml" \
+            "    channels:" \
+            "      - $CHANNEL" \
+            "    replaces: $REPLACES" \
+            > ./operators/project-quay/$TAG/release-config.yaml
 
       - name: Create Pull Request redhat-openshift-ecosystem
         uses: peter-evans/create-pull-request@v3
         with:
           token: ${{ secrets.PAT }}
-          commit-message: Add ${{ github.event.inputs.tag }} to community operators
+          commit-message: Add ${{ steps.tag.outputs.version }} to community operators
           author: quay-devel <quay-devel@redhat.com>
           push-to-fork: quay/community-operators-prod
           signoff: true
-          body: Add ${{ github.event.inputs.tag }} to community operators
+          body: Add ${{ steps.tag.outputs.version }} to community operators
           committer: quay-devel <quay-devel@redhat.com>
-          branch: create-pull-request/patch-${{ github.event.inputs.tag }}
+          branch: create-pull-request/patch-${{ steps.tag.outputs.version }}
 
   pull-request-k8s-operatorhub:
     name: "Create Pull Request against Community Operators Repo"
     runs-on: ubuntu-latest
     needs: ["pull-request-redhat-openshift-ecosystem"]
     steps:
+      - name: Strip v prefix from tag
+        id: tag
+        run: |
+          TAG="${{ github.event.inputs.tag }}"
+          TAG="${TAG#v}"
+          echo "version=$TAG" >> $GITHUB_OUTPUT
+
       - name: Check out Quay k8s-operatorhub/community-operators fork
         uses: actions/checkout@v3
         with:
           repository: k8s-operatorhub/community-operators
           token: ${{ secrets.PAT }}
 
-      - name: Download community operators repo and pull in prod updates
+      - name: Copy new version from community-operators-prod
         run: |
-          git clone --branch create-pull-request/patch-${{ github.event.inputs.tag }} https://${{ secrets.PAT }}@github.com/quay/community-operators-prod.git
-          rm -rf operators/project-quay
-          mv community-operators-prod/operators/project-quay operators
+          TAG="${{ steps.tag.outputs.version }}"
+          git clone --branch create-pull-request/patch-$TAG https://${{ secrets.PAT }}@github.com/quay/community-operators-prod.git
+          cp -r community-operators-prod/operators/project-quay/$TAG operators/project-quay/
           rm -rf community-operators-prod
 
       - name: Create Pull Request k8s-operatorhub
         uses: peter-evans/create-pull-request@v3
         with:
           token: ${{ secrets.PAT }}
-          commit-message: Add ${{ github.event.inputs.tag }} to community operators
+          commit-message: Add ${{ steps.tag.outputs.version }} to community operators
           author: quay-devel <quay-devel@redhat.com>
           push-to-fork: quay/community-operators
           signoff: true
-          body: Add ${{ github.event.inputs.tag }} to community operators
+          body: Add ${{ steps.tag.outputs.version }} to community operators
           committer: quay-devel <quay-devel@redhat.com>
-          branch: create-pull-request/patch-${{ github.event.inputs.tag }}
+          branch: create-pull-request/patch-${{ steps.tag.outputs.version }}
           delete-branch: true


### PR DESCRIPTION
## Summary

- **Strip v prefix from tag input**: If someone enters `v3.12.15` as the tag, the directory was created as `v3.12.15` instead of `3.12.15`. This has happened 3 times already (v3.9.19, v3.10.19, v3.12.15 in community-operators-prod). Now the `v` prefix is stripped at the start of both the community-operators-prod and k8s-operatorhub jobs.

- **Fix version detection with v-prefixed directories**: The `sort -V` command sorts `v3.12.15` higher than `3.12.16` (because `v` > digit characters), causing the workflow to pick the wrong previous version and produce double-v strings like `quay-operator.vv3.12.15`. The version detection loop and DEFAULT_CHANNEL detection now strip the `v` prefix from directory names before comparison.

- **Fix k8s-operatorhub wholesale directory replacement**: The k8s-operatorhub job previously did `rm -rf operators/project-quay` and replaced the entire directory from community-operators-prod. This pulled in divergent content (v-prefixed dirs, FBC-specific files) that doesn't belong in k8s-operatorhub. Changed to only copy the new version directory.

- **Add release-config.yaml generation for FBC**: After FBC onboarding of project-quay in community-operators-prod, each new bundle needs a `release-config.yaml` file specifying the catalog template, channel, and replaces value. This follows the same single `basic.yaml` template pattern used by other operators (sailoperator, alloydb-omni-operator).

## Context

This PR complements the FBC (File-Based Catalog) onboarding of project-quay in `redhat-openshift-ecosystem/community-operators-prod`. The release-config.yaml generation ensures that automated releases produce FBC-compatible bundles going forward.

## Test plan

- [ ] Verify workflow YAML syntax is valid
- [ ] Test with a tag like `v3.14.8` to confirm v prefix is stripped correctly
- [ ] Test with a tag like `3.14.8` to confirm it works without the prefix
- [ ] Verify the generated release-config.yaml matches the expected FBC format
- [ ] Verify k8s-operatorhub job only copies the new version directory

Generated with [Claude Code](https://claude.com/claude-code)